### PR TITLE
Update ike.keyfile.cpp to work with OpenSSL 3.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -326,11 +326,18 @@ endif( NOT CMAKE_USE_PTHREADS_INIT )
 
 if( NOT APPLE )
 
-	check_library_exists(
-		${CMAKE_THREAD_LIBS_INIT}
-		"pthread_mutex_timedlock"
-		""
-		FUNC_LIB_TIMEDLOCK )
+#	check_library_exists(
+#		${CMAKE_THREAD_LIBS_INIT}
+#		"pthread_mutex_timedlock"
+#		""
+#		FUNC_LIB_TIMEDLOCK )
+
+     check_library_exists(
+         pthread
+         pthread_mutex_timedlock
+         pthread.h
+         FUNC_LIB_TIMEDLOCK )
+
 
 endif( NOT APPLE )
 

--- a/source/iked/ike.keyfile.cpp
+++ b/source/iked/ike.keyfile.cpp
@@ -858,7 +858,7 @@ bool prvkey_rsa_load_pem( BDATA & prvkey, FILE * fp, BDATA & pass )
 	if( evp_pkey == NULL )
 		return false;
 
-	bool converted = prvkey_rsa_2_bdata( prvkey, EVP_PKEY_get0_RSA( evp_pkey ) );
+	bool converted = prvkey_rsa_2_bdata( prvkey, (rsa_st*)EVP_PKEY_get0_RSA( evp_pkey ) );
 	EVP_PKEY_free( evp_pkey );
 
 	return converted;
@@ -884,7 +884,7 @@ bool prvkey_rsa_load_p12( BDATA & prvkey, FILE * fp, BDATA & pass )
 	if( evp_pkey == NULL )
 		return false;
 
-	bool converted = prvkey_rsa_2_bdata( prvkey, EVP_PKEY_get0_RSA( evp_pkey ) );
+	bool converted = prvkey_rsa_2_bdata( prvkey, (rsa_st*)EVP_PKEY_get0_RSA( evp_pkey ) );
 	EVP_PKEY_free( evp_pkey );
 
 	return converted;
@@ -940,7 +940,7 @@ bool prvkey_rsa_load_pem( BDATA & prvkey, BDATA & input, BDATA & pass )
 	if( evp_pkey == NULL )
 		return false;
 
-	bool converted = prvkey_rsa_2_bdata( prvkey, EVP_PKEY_get0_RSA( evp_pkey ) );
+	bool converted = prvkey_rsa_2_bdata( prvkey, (rsa_st*)EVP_PKEY_get0_RSA( evp_pkey ) );
 	EVP_PKEY_free( evp_pkey );
 
 	return converted;
@@ -977,7 +977,7 @@ bool prvkey_rsa_load_p12( BDATA & prvkey, BDATA & input, BDATA & pass )
 	if( evp_pkey == NULL )
 		return false;
 
-	bool converted = prvkey_rsa_2_bdata( prvkey, EVP_PKEY_get0_RSA( evp_pkey ) );
+	bool converted = prvkey_rsa_2_bdata( prvkey, (rsa_st*)EVP_PKEY_get0_RSA( evp_pkey ) );
 	EVP_PKEY_free( evp_pkey );
 
 	return converted;
@@ -1011,7 +1011,7 @@ bool _IKED::pubkey_rsa_read( BDATA & cert, BDATA & pubkey )
 	if( evp_pkey == NULL )
 		return false;
 
-	bool result = pubkey_rsa_2_bdata( pubkey, EVP_PKEY_get0_RSA( evp_pkey ) );
+	bool result = pubkey_rsa_2_bdata( pubkey, (rsa_st*)EVP_PKEY_get0_RSA( evp_pkey ) );
 
 	EVP_PKEY_free( evp_pkey );
 


### PR DESCRIPTION
In OpenSSL 3.0 VP_PKEY_get0_RSA() now returns a pointer of type `const struct rsa_st*` to an immutable value. This has been made compatible with both OpenSSL 3.0.0 and earlier versions of OpenSSL by casting the returned value to `(rsa_st*)` as follows: `rsa = (rsa_st*)EVP_PKEY_get0_RSA(pubKey);`

Do not try to modify the contents of the returned struct.